### PR TITLE
Feat/reusable state machine

### DIFF
--- a/Assets/Scripts/StateMachine.meta
+++ b/Assets/Scripts/StateMachine.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 72c54829b396228418ee09b30535bbec
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/StateMachine/BaseState.cs
+++ b/Assets/Scripts/StateMachine/BaseState.cs
@@ -16,7 +16,6 @@ public abstract class BaseState<EState> where EState : Enum
         StateKey = stateKey;
     }
 
-    public abstract EState GetNextState();
     public abstract void EnterState();
     public abstract void ExitState();
     public abstract void OnTriggerEnter(Collider otherCollider);

--- a/Assets/Scripts/StateMachine/BaseState.cs
+++ b/Assets/Scripts/StateMachine/BaseState.cs
@@ -1,0 +1,26 @@
+using System;
+using UnityEngine;
+
+/// <summary>
+/// A reusable state machine manager to apply to various objects that requires a state machine.
+/// This was referenced from "Programming A BETTER State Machine" by iHeartGameDev on YouTube:
+/// https://www.youtube.com/watch?v=qsIiFsddGV4
+/// </summary>
+/// <typeparam name="EState"></typeparam>
+public abstract class BaseState<EState> where EState : Enum
+{
+    public EState StateKey {  get; set; }
+
+    public BaseState(EState stateKey)
+    {
+        StateKey = stateKey;
+    }
+
+    public abstract EState GetNextState();
+    public abstract void EnterState();
+    public abstract void ExitState();
+    public abstract void OnTriggerEnter(Collider otherCollider);
+    public abstract void OnTriggerExit(Collider otherCollider);
+    public abstract void OnTriggerStay(Collider otherCollider);
+    public abstract void UpdateState();
+}

--- a/Assets/Scripts/StateMachine/BaseState.cs
+++ b/Assets/Scripts/StateMachine/BaseState.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 /// This was referenced from "Programming A BETTER State Machine" by iHeartGameDev on YouTube:
 /// https://www.youtube.com/watch?v=qsIiFsddGV4
 /// </summary>
-/// <typeparam name="EState"></typeparam>
+/// <typeparam name="EState">The enumerable type representing the possible states</typeparam>
 public abstract class BaseState<EState> where EState : Enum
 {
     public EState StateKey {  get; set; }

--- a/Assets/Scripts/StateMachine/BaseState.cs.meta
+++ b/Assets/Scripts/StateMachine/BaseState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 46bc3f7d59467384e8b8921fea22bf9b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/StateMachine/StateManager.cs
+++ b/Assets/Scripts/StateMachine/StateManager.cs
@@ -24,22 +24,13 @@ public abstract class StateManager<EState> : MonoBehaviour where EState : Enum
     }
 
     /// <summary>
-    /// Updates the current state or transitions to a new state based on the next state key.
+    /// Trigger the update loop for the current state.
     /// </summary>
     private void Update()
     {
-        EState nextStateKey = CurrentState.GetNextState();
-
         if (!_isTransitioningState)
         {
-            if (nextStateKey.Equals(CurrentState.StateKey))
-            {
-                CurrentState.UpdateState();
-            }
-            else
-            {
-                TransitionToState(nextStateKey);
-            }
+            CurrentState.UpdateState();
         }
     }
 
@@ -74,14 +65,17 @@ public abstract class StateManager<EState> : MonoBehaviour where EState : Enum
     /// Transition from the current state to the given state.
     /// </summary>
     /// <param name="stateKey">The enumerable member to transition to</param>
-    private void TransitionToState(EState stateKey)
+    protected void TransitionToState(EState stateKey)
     {
-        _isTransitioningState = true;
+        if (!CurrentState.StateKey.Equals(stateKey))
+        {
+            _isTransitioningState = true;
 
-        CurrentState.ExitState();
-        CurrentState = States[stateKey];
-        CurrentState.EnterState();
+            CurrentState.ExitState();
+            CurrentState = States[stateKey];
+            CurrentState.EnterState();
 
-        _isTransitioningState = false;
+            _isTransitioningState = false;
+        }
     }
 }

--- a/Assets/Scripts/StateMachine/StateManager.cs
+++ b/Assets/Scripts/StateMachine/StateManager.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// A reusable state machine manager to apply to various objects that requires a state machine.
+/// This was referenced from "Programming A BETTER State Machine" by iHeartGameDev on YouTube:
+/// https://www.youtube.com/watch?v=qsIiFsddGV4
+/// </summary>
+/// <typeparam name="EState">The enumerable type representing the possible states</typeparam>
+public abstract class StateManager<EState> : MonoBehaviour where EState : Enum
+{
+    protected Dictionary<EState, BaseState<EState>> States = new Dictionary<EState, BaseState<EState>>();
+    protected BaseState<EState> CurrentState;
+    
+    protected bool _isTransitioningState = false;
+
+    /// <summary>
+    /// Enter the current state.
+    /// </summary>
+    private void Start()
+    {
+        CurrentState.EnterState();
+    }
+
+    /// <summary>
+    /// Updates the current state or transitions to a new state based on the next state key.
+    /// </summary>
+    private void Update()
+    {
+        EState nextStateKey = CurrentState.GetNextState();
+
+        if (!_isTransitioningState)
+        {
+            if (nextStateKey.Equals(CurrentState.StateKey))
+            {
+                CurrentState.UpdateState();
+            }
+            else
+            {
+                TransitionToState(nextStateKey);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Called when another collider enters the trigger attached to the current gameObject.
+    /// </summary>
+    /// <param name="otherCollider">The other collider involved in this collision</param>
+    private void OnTriggerEnter(Collider otherCollider)
+    {
+        CurrentState.OnTriggerEnter(otherCollider);
+    }
+
+    /// <summary>
+    /// Called when another collider exits the trigger attached to the current gameObject.
+    /// </summary>
+    /// <param name="otherCollider">The other collider involved in this collision</param>
+    private void OnTriggerExit(Collider otherCollider)
+    {
+        CurrentState.OnTriggerExit(otherCollider);
+    }
+
+    /// <summary>
+    /// Called when another collider continues to enable the trigger attached to the current gameObject.
+    /// </summary>
+    /// <param name="otherCollider">The other collider involved in this collision</param>
+    private void OnTriggerStay(Collider otherCollider)
+    {
+        CurrentState.OnTriggerStay(otherCollider);
+    }
+
+    /// <summary>
+    /// Transition from the current state to the given state.
+    /// </summary>
+    /// <param name="stateKey">The enumerable member to transition to</param>
+    private void TransitionToState(EState stateKey)
+    {
+        _isTransitioningState = true;
+
+        CurrentState.ExitState();
+        CurrentState = States[stateKey];
+        CurrentState.EnterState();
+
+        _isTransitioningState = false;
+    }
+}

--- a/Assets/Scripts/StateMachine/StateManager.cs.meta
+++ b/Assets/Scripts/StateMachine/StateManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0fa7da5233f97e14e8fe7d645a935695
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This reusable finite state machine is a generic class type that allows us to add a finite state to any gameObject we want.

More specifically, we would ideally use this for gameObjects that have multiple states such as players, enemies, interactable puzzles, and more (maybe even procedural animation in the future?).

Currently, there is no reference file on how to implement this generic class type, but I plan on creating a new branch and integrating it into the player controller as soon as possible to have some sort of complete reference.

The code provided was referenced from iHeartGameDev's YouTube videos on [How to Program in Unity: State Machines Explained](https://www.youtube.com/watch?v=Vt8aZDPzRjI&t=783s), [Programming a BETTER state machine](https://www.youtube.com/watch?v=qsIiFsddGV4&t=7s), and [How to Program in Unity: Using my "BETTER" State Machine for Procedural Animation](https://www.youtube.com/watch?v=N3jOOm--TTg).

***Watchtime (on 1x speed): 42 minutes**