### PR TITLE
Fix build errors related to cloning `BaseState` instances

### DIFF
--- a/Assets/Prefabs/Enemies/FlyingEnemy.prefab
+++ b/Assets/Prefabs/Enemies/FlyingEnemy.prefab
@@ -340,6 +340,7 @@ MonoBehaviour:
   - Key: 3
     Value: {fileID: 11400000, guid: cf0eb6033cc4573439550dfb17f63cd1, type: 2}
   _defaultState: 0
+  _cloneStates: 1
   _attackStats:
     _attackCooldown: 3
     _attackDamage: 5

--- a/Assets/Prefabs/Enemies/GroundEnemy.prefab
+++ b/Assets/Prefabs/Enemies/GroundEnemy.prefab
@@ -415,6 +415,8 @@ MonoBehaviour:
   syncDirection: 0
   syncMode: 0
   syncInterval: 0
+  _cloneStates: 1
+  _defaultState: 0
   StateMappings:
   - Key: 0
     Value: {fileID: 11400000, guid: 5d42863c08d29a9499efbf073d9f5cfe, type: 2}
@@ -424,7 +426,6 @@ MonoBehaviour:
     Value: {fileID: 11400000, guid: ae2e8beaf453cf24aa0c520cacfa34e4, type: 2}
   - Key: 3
     Value: {fileID: 11400000, guid: cf0eb6033cc4573439550dfb17f63cd1, type: 2}
-  _defaultState: 0
   _attackStats:
     _attackCooldown: 3
     _attackDamage: 5

--- a/Assets/Scenes/Network-Lobby.unity
+++ b/Assets/Scenes/Network-Lobby.unity
@@ -356,7 +356,7 @@ MonoBehaviour:
   autoStartServerBuild: 0
   autoConnectClientBuild: 0
   offlineScene: Assets/Scenes/Network-Lobby.unity
-  onlineScene: Assets/Scenes/Gameplay/Gameplay-Intermission.unity
+  onlineScene: Assets/Scenes/Dungeon1.unity
   transport: {fileID: 647847493}
   networkAddress: localhost
   maxConnections: 100

--- a/Assets/Scripts/Abstract/AbstractBillboard.cs
+++ b/Assets/Scripts/Abstract/AbstractBillboard.cs
@@ -52,7 +52,12 @@ public class AbstractBillboard : MonoBehaviour
 
         if (localPlayer != null)
         {
-            _playerCamera = localPlayer.GetComponentInChildren<Camera>().transform;
+            Camera maybeCamera = localPlayer.GetComponent<Camera>();
+
+            if (maybeCamera != null)
+            {
+                _playerCamera = maybeCamera.transform;
+            }
         }
         else if (_maxAttempts <= _currentAttempts)
         {

--- a/Assets/Scripts/Enemy/StateMachine/Aiming State.asset
+++ b/Assets/Scripts/Enemy/StateMachine/Aiming State.asset
@@ -10,5 +10,5 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: a4a51448a879bd444b4f08a15087bf4e, type: 3}
-  m_Name: Aiming State
+  m_Name: Aiming State(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)
   m_EditorClassIdentifier: 

--- a/Assets/Scripts/Enemy/StateMachine/Attacking State.asset
+++ b/Assets/Scripts/Enemy/StateMachine/Attacking State.asset
@@ -10,5 +10,5 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: c5298d0d09a485b48a13bec23d513e8d, type: 3}
-  m_Name: Attacking State
+  m_Name: Attacking State(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)
   m_EditorClassIdentifier: 

--- a/Assets/Scripts/Enemy/StateMachine/Chasing State.asset
+++ b/Assets/Scripts/Enemy/StateMachine/Chasing State.asset
@@ -10,5 +10,5 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 455554784f498914fb04d8d5fd2ff642, type: 3}
-  m_Name: Chasing State
+  m_Name: Chasing State(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)
   m_EditorClassIdentifier: 

--- a/Assets/Scripts/Enemy/StateMachine/Idle State.asset
+++ b/Assets/Scripts/Enemy/StateMachine/Idle State.asset
@@ -10,6 +10,6 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 61c0658cdd2668546afa26664d87bf63, type: 3}
-  m_Name: Idle State
+  m_Name: Idle State(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)(Clone)
   m_EditorClassIdentifier: 
   _rotationSpeed: 1.5

--- a/Assets/Scripts/Gameplay/States/Gameplay Boss.asset.meta
+++ b/Assets/Scripts/Gameplay/States/Gameplay Boss.asset.meta
@@ -2,7 +2,7 @@ fileFormatVersion: 2
 guid: 4f0a189b52c10c346b8badabc6827938
 NativeFormatImporter:
   externalObjects: {}
-  mainObjectFileID: 11400000
+  mainObjectFileID: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/Scripts/Gameplay/States/Gameplay Defeat.asset.meta
+++ b/Assets/Scripts/Gameplay/States/Gameplay Defeat.asset.meta
@@ -2,7 +2,7 @@ fileFormatVersion: 2
 guid: 1e92d03e1aead284b92bdbeafe69ce76
 NativeFormatImporter:
   externalObjects: {}
-  mainObjectFileID: 11400000
+  mainObjectFileID: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/Scripts/Gameplay/States/Gameplay Dungeon.asset.meta
+++ b/Assets/Scripts/Gameplay/States/Gameplay Dungeon.asset.meta
@@ -2,7 +2,7 @@ fileFormatVersion: 2
 guid: 8304c387e7384af489567a77285218d7
 NativeFormatImporter:
   externalObjects: {}
-  mainObjectFileID: 11400000
+  mainObjectFileID: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/Scripts/Gameplay/States/Gameplay Intermission.asset.meta
+++ b/Assets/Scripts/Gameplay/States/Gameplay Intermission.asset.meta
@@ -2,7 +2,7 @@ fileFormatVersion: 2
 guid: b27c314ba5e29364fa9f0f67bccf400d
 NativeFormatImporter:
   externalObjects: {}
-  mainObjectFileID: 11400000
+  mainObjectFileID: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/Scripts/Gameplay/States/Gameplay Preparation.asset.meta
+++ b/Assets/Scripts/Gameplay/States/Gameplay Preparation.asset.meta
@@ -2,7 +2,7 @@ fileFormatVersion: 2
 guid: 9297fce9ee06b03468d5bc8d6c3d0a8c
 NativeFormatImporter:
   externalObjects: {}
-  mainObjectFileID: 11400000
+  mainObjectFileID: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/Scripts/StateMachine/BaseState.cs
+++ b/Assets/Scripts/StateMachine/BaseState.cs
@@ -1,4 +1,5 @@
 using System;
+using Unity.VisualScripting;
 using UnityEditor;
 using UnityEngine;
 
@@ -29,10 +30,10 @@ public abstract class BaseState<EState, TStateContext> : ScriptableObject where 
     /// <returns>A cloned instance of this state.</returns>
     public BaseState<EState, TStateContext> Clone()
     {
-        var clonedInstance = (BaseState<EState, TStateContext>)ScriptableObject.CreateInstance(GetType());
+        var clonedInstance = Instantiate(this);
 
-        UnityUtils.CloneNonSerializedData(this, clonedInstance);
-        UnityUtils.CloneSerializedData(this, clonedInstance);
+        GeneralUtils.CloneFieldData(clonedInstance, this);
+        GeneralUtils.ClonePropertyData(clonedInstance, this);
 
         return clonedInstance;
     }

--- a/Assets/Scripts/StateMachine/StateManager.cs
+++ b/Assets/Scripts/StateMachine/StateManager.cs
@@ -18,9 +18,11 @@ public abstract class StateManager<EState, TState, TStateContext> : NetworkBehav
     where TState : BaseState<EState, TStateContext>
 {
     [Header("State Paramaters")]
+    [SerializeField] private bool _cloneStates;
+    [SerializeField] private EState _defaultState;
+
     [Tooltip("Associates each state with its corresponding behavior.")]
     [SerializeField] protected List<StateMapping<EState, TStateContext>> StateMappings;
-    [SerializeField] private EState _defaultState;
 
     protected Dictionary<EState, BaseState<EState, TStateContext>> States;
     protected BaseState<EState, TStateContext> CurrentState;
@@ -53,7 +55,7 @@ public abstract class StateManager<EState, TState, TStateContext> : NetworkBehav
                 // Since we are using Scriptable Objects to enable a "drag-n-drop" behavior in the Unity Inspector,
                 // we need to ensure that we create separate instances in order to prevent syncing state behavior.
                 EState stateKey = currentState.Key;
-                TState stateInstance = (TState)currentState.Value.Clone();
+                TState stateInstance = (TState)(_cloneStates ? currentState.Value.Clone() : currentState.Value);
                 
                 stateInstance.Initialize(stateKey, StateContext);
 

--- a/Assets/Scripts/Utils/UnityUtils.cs
+++ b/Assets/Scripts/Utils/UnityUtils.cs
@@ -11,42 +11,6 @@ using UnityEngine.UIElements;
 public static class UnityUtils
 {
     /// <summary>
-    /// Clones the non-serialized field sand properties from the source object to the target object.
-    /// This EXCLUDES fields and properties that are as [SerializedField].
-    /// </summary>
-    /// <param name="sourceObject">The source object from which data will be cloned.</param>
-    /// <param name="targetObject">The target object to which data will be cloned.</param>
-    public static void CloneNonSerializedData(UnityEngine.Object sourceObject, UnityEngine.Object targetObject)
-    {
-        GeneralUtils.CloneFieldData(sourceObject, targetObject);
-        GeneralUtils.ClonePropertyData(sourceObject, targetObject);
-    }
-
-    /// <summary>
-    /// Clones the serialized data from the source object to the target object.
-    /// This INCLUDES fields and properties that are as [SerializedField].
-    /// </summary>
-    /// <remarks>
-    /// We may need to update this code in order to work in builds as <see cref="SerializedObject"/> is only available in the editor.
-    /// </remarks>
-    /// <param name="sourceObject">The source object from which data will be cloned.</param>
-    /// <param name="targetObject">The target object to which data will be cloned.</param>
-    public static void CloneSerializedData(UnityEngine.Object sourceObject, UnityEngine.Object targetObject)
-    {
-        SerializedObject serializedSource = new SerializedObject(sourceObject);
-        SerializedObject serializedTarget = new SerializedObject(targetObject);
-
-        SerializedProperty serializedProperty = serializedSource.GetIterator();
-
-        while (serializedProperty.NextVisible(true))
-        {
-            serializedTarget.CopyFromSerializedProperty(serializedProperty);
-        }
-
-        serializedTarget.ApplyModifiedProperties();
-    }
-
-    /// <summary>
     /// Checks if a specific layer is included within a given <see cref="LayerMask"/>
     /// </summary>
     /// <param name="layerMask">The <see cref="LayerMask"/> to check.</param>


### PR DESCRIPTION
Previously, the following code would not run due to it being only available for the Unity Editor

```
    public static void CloneNonSerializedData(UnityEngine.Object sourceObject, UnityEngine.Object targetObject)
    {
        GeneralUtils.CloneFieldData(sourceObject, targetObject);
        GeneralUtils.ClonePropertyData(sourceObject, targetObject);
    }

    public static void CloneSerializedData(UnityEngine.Object sourceObject, UnityEngine.Object targetObject)
    {
        SerializedObject serializedSource = new SerializedObject(sourceObject);
        SerializedObject serializedTarget = new SerializedObject(targetObject);

        SerializedProperty serializedProperty = serializedSource.GetIterator();

        while (serializedProperty.NextVisible(true))
        {
            serializedTarget.CopyFromSerializedProperty(serializedProperty);
        }

        serializedTarget.ApplyModifiedProperties();
    }
```

This code has since been removed and updated.

Ideally, we would probably want to change this implementation off of a Scriptable Object into a more custom class type that is able to be built off of single, then multiplied instances (as Scriptable Objects can be commonly thought of like global data containers) but if it works it works