### PR TITLE
Resolve object naming warnings for `BaseState`

### DIFF
--- a/Assets/Scripts/StateMachine/BaseState.cs
+++ b/Assets/Scripts/StateMachine/BaseState.cs
@@ -32,6 +32,7 @@ public abstract class BaseState<EState, TStateContext> : ScriptableObject where 
     {
         var clonedInstance = Instantiate(this);
 
+        clonedInstance.name = name;
         GeneralUtils.CloneFieldData(clonedInstance, this);
         GeneralUtils.ClonePropertyData(clonedInstance, this);
 

--- a/ProjectSettings/Packages/com.unity.probuilder/Settings.json
+++ b/ProjectSettings/Packages/com.unity.probuilder/Settings.json
@@ -14,7 +14,7 @@
             {
                 "type": "UnityEngine.ProBuilder.SelectMode, Unity.ProBuilder, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                 "key": "editor.selectMode",
-                "value": "{\"m_Value\":8}"
+                "value": "{\"m_Value\":1}"
             },
             {
                 "type": "UnityEngine.ProBuilder.SelectMode, Unity.ProBuilder, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",


### PR DESCRIPTION
fixed this monstrosity
(this shouldn't occur again... hopefully)

![image](https://github.com/user-attachments/assets/a91e7f13-0ff7-40ac-a615-a1ff0d8d1d6d)
