### PR TITLE
Feat/scoreboard kills

### DIFF
--- a/Assets/Scripts/Abstract/AbstractHealth.cs
+++ b/Assets/Scripts/Abstract/AbstractHealth.cs
@@ -43,7 +43,7 @@ public abstract class AbstractHealth : NetworkBehaviour
     public float CurrentValue
     {
         get => _currentValue;
-        private set
+        protected set
         {
             _currentValue = Mathf.Clamp(value, 0f, BaseValue);
         }

--- a/Assets/Scripts/Enemy/EnemyHealth.cs
+++ b/Assets/Scripts/Enemy/EnemyHealth.cs
@@ -68,6 +68,7 @@ public class EnemyHealth : AbstractHealth
         }
         _latestSource = sourceId;
         if (CurrentValue <= 0f) { TriggerDeath(); }
+        // TODO: If the enemy has no target, make it aggro on the player who did damage
     }
 
     /// <summary>

--- a/Assets/Scripts/PlayerController/CombatController.cs
+++ b/Assets/Scripts/PlayerController/CombatController.cs
@@ -92,8 +92,14 @@ public class CombatController : NetworkBehaviour
                 {
                     Debug.Log("Normal Attack. Damage: " + finalDamage);
                 }
-
-                healthComponent.CmdDamage(finalDamage);
+                if (healthComponent is EnemyHealth enemyHealth)
+                {
+                    enemyHealth.CmdDamageSource(finalDamage, netId);
+                }
+                else
+                {
+                    healthComponent.CmdDamage(finalDamage);
+                }
             }
         }
     }

--- a/Assets/Scripts/PlayerController/CombatController.cs
+++ b/Assets/Scripts/PlayerController/CombatController.cs
@@ -148,6 +148,7 @@ public class CombatController : NetworkBehaviour
       
         projectileComponent.AttackDamage = finalDamage;
         projectileComponent.AttackLayers = rangedWeapon.AttackLayers;
+        projectileComponent.SourceId = netId;
         projectileComponent.transform.LookAt(finalPosition);
 
         Vector3 targetDirection = (finalPosition - initialPosition).normalized;

--- a/Assets/Scripts/Projectile.cs
+++ b/Assets/Scripts/Projectile.cs
@@ -7,6 +7,7 @@ public class Projectile : NetworkBehaviour
     public float AttackDamage;
     public LayerMask AttackLayers;
     public LayerMask IgnoreLayers;
+    public uint SourceId;
 
     /// <summary>
     /// Handles collision events for the object.
@@ -21,7 +22,15 @@ public class Projectile : NetworkBehaviour
 
             if (UnityUtils.ContainsLayer(AttackLayers, collisionObject.layer) && collisionObject.TryGetComponent(out AbstractHealth healthComponent))
             {
-                healthComponent.CmdDamage(AttackDamage);
+                if (healthComponent is EnemyHealth enemyHealth)
+                {
+                    enemyHealth.CmdDamageSource(AttackDamage, SourceId);
+                }
+                else
+                {
+                    healthComponent.CmdDamage(AttackDamage);
+                }
+                //healthComponent.CmdDamage(AttackDamage);
             }
 
             if (!UnityUtils.ContainsLayer(IgnoreLayers, collisionObject.layer))

--- a/Assets/Scripts/Projectile.cs
+++ b/Assets/Scripts/Projectile.cs
@@ -30,7 +30,6 @@ public class Projectile : NetworkBehaviour
                 {
                     healthComponent.CmdDamage(AttackDamage);
                 }
-                //healthComponent.CmdDamage(AttackDamage);
             }
 
             if (!UnityUtils.ContainsLayer(IgnoreLayers, collisionObject.layer))


### PR DESCRIPTION
- Every time a player kills an enemy, their kill count on the scoreboard is incremented
- When an enemy dies, all players who dealt damage to them (except the player that killed it) gets an assist
- Works for melee and ranged weapons